### PR TITLE
モード・マップ階層での集計機能を追加

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -25,18 +25,27 @@ def load_ranks():
     with sqlite3.connect(DB_PATH) as conn:
         return pd.read_sql_query("SELECT id, name_ja FROM _ranks ORDER BY id", conn)
 
-def brawler_usage(map_id, rank_id):
+def brawler_usage(mode_id, map_id=None, rank_id=None):
+    """指定した階層でのキャラ使用率を集計する"""
+    query = (
+        "SELECT b.name_ja AS brawler, SUM(bur.count) AS count "
+        "FROM brawler_used_ranks bur "
+        "JOIN _brawlers b ON bur.brawler_id = b.id "
+        "JOIN _maps m ON bur.map_id = m.id WHERE 1=1"
+    )
+    params = []
+    if mode_id is not None:
+        query += " AND m.mode_id=?"
+        params.append(mode_id)
+    if map_id is not None:
+        query += " AND bur.map_id=?"
+        params.append(map_id)
+    if rank_id is not None:
+        query += " AND bur.rank_id=?"
+        params.append(rank_id)
+    query += " GROUP BY b.name_ja"
     with sqlite3.connect(DB_PATH) as conn:
-        df = pd.read_sql_query(
-            """
-            SELECT b.name_ja AS brawler, bur.count
-            FROM brawler_used_ranks bur
-            JOIN _brawlers b ON bur.brawler_id = b.id
-            WHERE bur.map_id=? AND bur.rank_id=?
-            """,
-            conn,
-            params=(map_id, rank_id),
-        )
+        df = pd.read_sql_query(query, conn, params=params)
     total = df["count"].sum()
     if total > 0:
         df["usage_rate"] = df["count"] / total * 100
@@ -44,38 +53,72 @@ def brawler_usage(map_id, rank_id):
         df["usage_rate"] = 0
     return df.sort_values("usage_rate", ascending=False)
 
-def brawler_win_rate(map_id, rank_id):
+def brawler_win_rate(mode_id, map_id=None, rank_id=None):
+    """指定した階層でのキャラ勝率を集計する"""
+    base = (
+        "FROM win_lose_logs w "
+        "JOIN battle_logs bl ON w.battle_log_id = bl.id "
+        "JOIN rank_logs rl ON bl.rank_log_id = rl.id "
+        "JOIN _maps m ON rl.map_id = m.id WHERE 1=1"
+    )
+    params = []
+    if mode_id is not None:
+        base += " AND m.mode_id=?"
+        params.append(mode_id)
+    if map_id is not None:
+        base += " AND rl.map_id=?"
+        params.append(map_id)
+    if rank_id is not None:
+        base += " AND rl.rank_id=?"
+        params.append(rank_id)
     with sqlite3.connect(DB_PATH) as conn:
         wins = pd.read_sql_query(
-            """
-            SELECT w.win_brawler_id AS brawler_id, COUNT(*) AS wins
-            FROM win_lose_logs w
-            JOIN battle_logs bl ON w.battle_log_id = bl.id
-            JOIN rank_logs rl ON bl.rank_log_id = rl.id
-            WHERE rl.map_id=? AND rl.rank_id=?
-            GROUP BY w.win_brawler_id
-            """,
+            "SELECT w.win_brawler_id AS brawler_id, COUNT(*) AS wins " + base + " GROUP BY w.win_brawler_id",
             conn,
-            params=(map_id, rank_id),
+            params=params,
         )
         losses = pd.read_sql_query(
-            """
-            SELECT w.lose_brawler_id AS brawler_id, COUNT(*) AS losses
-            FROM win_lose_logs w
-            JOIN battle_logs bl ON w.battle_log_id = bl.id
-            JOIN rank_logs rl ON bl.rank_log_id = rl.id
-            WHERE rl.map_id=? AND rl.rank_id=?
-            GROUP BY w.lose_brawler_id
-            """,
+            "SELECT w.lose_brawler_id AS brawler_id, COUNT(*) AS losses "
+            + base
+            + " GROUP BY w.lose_brawler_id",
             conn,
-            params=(map_id, rank_id),
+            params=params,
         )
+        brawlers = pd.read_sql_query("SELECT id, name_ja FROM _brawlers", conn)
     df = pd.merge(wins, losses, on="brawler_id", how="outer").fillna(0)
     df["total"] = df["wins"] + df["losses"]
     df["win_rate"] = (df["wins"] / df["total"]) * 100
-    brawlers = pd.read_sql_query("SELECT id, name_ja FROM _brawlers", conn)
     df = df.merge(brawlers, left_on="brawler_id", right_on="id").drop("id", axis=1)
     return df.rename(columns={"name_ja": "brawler"}).sort_values("win_rate", ascending=False)
+
+def battle_counts(mode_id, map_id=None, rank_id=None):
+    """各階層での対戦数を取得する"""
+    with sqlite3.connect(DB_PATH) as conn:
+        overall = conn.execute("SELECT COUNT(*) FROM battle_logs").fetchone()[0]
+        mode = conn.execute(
+            "SELECT COUNT(*) FROM battle_logs bl "
+            "JOIN rank_logs rl ON bl.rank_log_id = rl.id "
+            "JOIN _maps m ON rl.map_id = m.id WHERE m.mode_id=?",
+            (mode_id,),
+        ).fetchone()[0]
+        if map_id is not None:
+            map_total = conn.execute(
+                "SELECT COUNT(*) FROM battle_logs bl "
+                "JOIN rank_logs rl ON bl.rank_log_id = rl.id WHERE rl.map_id=?",
+                (map_id,),
+            ).fetchone()[0]
+        else:
+            map_total = mode
+        if map_id is not None and rank_id is not None:
+            rank_total = conn.execute(
+                "SELECT COUNT(*) FROM battle_logs bl "
+                "JOIN rank_logs rl ON bl.rank_log_id = rl.id "
+                "WHERE rl.map_id=? AND rl.rank_id=?",
+                (map_id, rank_id),
+            ).fetchone()[0]
+        else:
+            rank_total = map_total
+    return {"all": overall, "mode": mode, "map": map_total, "rank": rank_total}
 
 def matchup_rates(map_id, brawler_id):
     with sqlite3.connect(DB_PATH) as conn:
@@ -126,22 +169,35 @@ def main():
     mode_id = int(modes[modes["name_ja"] == mode_name]["id"].iloc[0])
 
     maps = load_maps(mode_id)
-    map_name = st.selectbox("マップ", maps["name_ja"])
-    map_id = int(maps[maps["name_ja"] == map_name]["id"].iloc[0])
+    map_options = ["全体"] + maps["name_ja"].tolist()
+    map_name = st.selectbox("マップ", map_options)
+    if map_name == "全体":
+        map_id = None
+    else:
+        map_id = int(maps[maps["name_ja"] == map_name]["id"].iloc[0])
 
     ranks = load_ranks()
-    rank_name = st.selectbox("ランク", ranks["name_ja"])
-    rank_id = int(ranks[ranks["name_ja"] == rank_name]["id"].iloc[0])
+    rank_options = ["全体"] + ranks["name_ja"].tolist()
+    rank_name = st.selectbox("ランク", rank_options)
+    if rank_name == "全体":
+        rank_id = None
+    else:
+        rank_id = int(ranks[ranks["name_ja"] == rank_name]["id"].iloc[0])
+
+    counts = battle_counts(mode_id, map_id, rank_id)
+    st.caption(
+        f"全体: {counts['all']} / モード: {counts['mode']} / マップ: {counts['map']} / ランク: {counts['rank']}"
+    )
 
     st.header("キャラ使用率")
-    usage_df = brawler_usage(map_id, rank_id)
+    usage_df = brawler_usage(mode_id, map_id, rank_id)
     if not usage_df.empty:
         st.bar_chart(usage_df.set_index("brawler")["usage_rate"])
     else:
         st.write("データがありません")
 
     st.header("キャラ勝率")
-    win_df = brawler_win_rate(map_id, rank_id)
+    win_df = brawler_win_rate(mode_id, map_id, rank_id)
     if not win_df.empty:
         st.bar_chart(win_df.set_index("brawler")["win_rate"])
     else:
@@ -149,14 +205,17 @@ def main():
 
     st.header("対キャラ勝率")
     with sqlite3.connect(DB_PATH) as conn:
-        brawlers = pd.read_sql_query("SELECT id, name_ja FROM _brawlers",conn)
+        brawlers = pd.read_sql_query("SELECT id, name_ja FROM _brawlers", conn)
     brawler_name = st.selectbox("キャラ", brawlers["name_ja"])
     brawler_id = int(brawlers[brawlers["name_ja"] == brawler_name]["id"].iloc[0])
-    match_df = matchup_rates(map_id, brawler_id)
-    if not match_df.empty:
-        st.dataframe(match_df)
+    if map_id is not None:
+        match_df = matchup_rates(map_id, brawler_id)
+        if not match_df.empty:
+            st.dataframe(match_df)
+        else:
+            st.write("データがありません")
     else:
-        st.write("データがありません")
+        st.write("マップを選択すると対キャラ勝率を表示します")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- モード・マップ・ランクの選択で下位階層を集計できるようにし、キャラの勝率と使用率を表示
- 各階層の総対戦数を表示
- マップ未選択時には対キャラ勝率を非表示に調整

## Testing
- `python -m py_compile dashboard.py`


------
https://chatgpt.com/codex/tasks/task_e_68a824bc57b4832b8b65e9f42ab6b62b