### PR TITLE
Add season-based statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,4 +25,4 @@ pip install streamlit pandas streamlit-autorefresh
 streamlit run dashboard.py
 ```
 
-モード・マップ・ランクを選択すると、キャラ使用率・勝率および対キャラ勝率を視覚的に確認できます。
+シーズン → モード → マップ → ランクを選択すると、キャラ使用率・勝率および対キャラ勝率を視覚的に確認できます。シーズンは毎月第1木曜日を開始日として計算されます。

--- a/dashboard.py
+++ b/dashboard.py
@@ -1,4 +1,6 @@
 import sqlite3
+from datetime import date, datetime, timedelta
+
 import pandas as pd
 import streamlit as st
 
@@ -9,9 +11,50 @@ except ModuleNotFoundError:  # pragma: no cover - optional dependency
 
 DB_PATH = "brawl_stats.db"
 
-# @st.cache_resource
-# def get_connection():
-#     return sqlite3.connect(DB_PATH)
+# シーズン計算用の基準値
+BASE_SEASON = 40
+BASE_START = date(2025, 7, 3)
+
+
+def first_thursday(year: int, month: int) -> date:
+    """指定した年月の第1木曜日を返す"""
+    d = date(year, month, 1)
+    while d.weekday() != 3:  # 0=Mon, 3=Thu
+        d += timedelta(days=1)
+    return d
+
+
+def season_from_date(d: date) -> int:
+    """日付からシーズン番号を求める"""
+    diff = (d.year - BASE_START.year) * 12 + (d.month - BASE_START.month)
+    if d < first_thursday(d.year, d.month):
+        diff -= 1
+    return BASE_SEASON + diff
+
+
+def season_range(season: int) -> tuple[date, date]:
+    """シーズン番号から開始日と次シーズン開始日を取得"""
+    diff = season - BASE_SEASON
+    year = BASE_START.year + (BASE_START.month - 1 + diff) // 12
+    month = (BASE_START.month - 1 + diff) % 12 + 1
+    start = first_thursday(year, month)
+    next_diff = diff + 1
+    next_year = BASE_START.year + (BASE_START.month - 1 + next_diff) // 12
+    next_month = (BASE_START.month - 1 + next_diff) % 12 + 1
+    next_start = first_thursday(next_year, next_month)
+    return start, next_start
+
+
+def load_seasons() -> list[int]:
+    """DBに存在するシーズン一覧を取得"""
+    with sqlite3.connect(DB_PATH) as conn:
+        dates = pd.read_sql_query(
+            "SELECT DISTINCT substr(id,1,8) AS date FROM battle_logs", conn
+        )["date"]
+    seasons = {
+        season_from_date(datetime.strptime(d, "%Y%m%d").date()) for d in dates
+    }
+    return sorted(seasons)
 
 def load_modes():
     with sqlite3.connect(DB_PATH) as conn:
@@ -29,23 +72,35 @@ def load_ranks():
     with sqlite3.connect(DB_PATH) as conn:
         return pd.read_sql_query("SELECT id, name_ja FROM _ranks ORDER BY id", conn)
 
-def brawler_usage(mode_id, map_id=None, rank_id=None):
+def brawler_usage(
+    season_id=None, mode_id=None, map_id=None, rank_id=None
+) -> pd.DataFrame:
     """指定した階層でのキャラ使用率を集計する"""
     query = (
-        "SELECT b.name_ja AS brawler, SUM(bur.count) AS count "
-        "FROM brawler_used_ranks bur "
-        "JOIN _brawlers b ON bur.brawler_id = b.id "
-        "JOIN _maps m ON bur.map_id = m.id WHERE 1=1"
+        "SELECT b.name_ja AS brawler, COUNT(*) AS count "
+        "FROM ("
+        " SELECT DISTINCT win_brawler_id AS brawler_id, battle_log_id FROM win_lose_logs"
+        " UNION ALL"
+        " SELECT DISTINCT lose_brawler_id AS brawler_id, battle_log_id FROM win_lose_logs"
+        ") wl "
+        "JOIN battle_logs bl ON wl.battle_log_id = bl.id "
+        "JOIN rank_logs rl ON bl.rank_log_id = rl.id "
+        "JOIN _maps m ON rl.map_id = m.id "
+        "JOIN _brawlers b ON wl.brawler_id = b.id WHERE 1=1"
     )
-    params = []
+    params: list = []
+    if season_id is not None:
+        start, next_start = season_range(season_id)
+        query += " AND substr(bl.id,1,8) >= ? AND substr(bl.id,1,8) < ?"
+        params.extend([start.strftime("%Y%m%d"), next_start.strftime("%Y%m%d")])
     if mode_id is not None:
         query += " AND m.mode_id=?"
         params.append(mode_id)
     if map_id is not None:
-        query += " AND bur.map_id=?"
+        query += " AND rl.map_id=?"
         params.append(map_id)
     if rank_id is not None:
-        query += " AND bur.rank_id=?"
+        query += " AND rl.rank_id=?"
         params.append(rank_id)
     query += " GROUP BY b.name_ja"
     with sqlite3.connect(DB_PATH) as conn:
@@ -57,7 +112,7 @@ def brawler_usage(mode_id, map_id=None, rank_id=None):
         df["usage_rate"] = 0
     return df.sort_values("usage_rate", ascending=False)
 
-def brawler_win_rate(mode_id, map_id=None, rank_id=None):
+def brawler_win_rate(season_id=None, mode_id=None, map_id=None, rank_id=None):
     """指定した階層でのキャラ勝率を集計する"""
     base = (
         "FROM win_lose_logs w "
@@ -65,7 +120,11 @@ def brawler_win_rate(mode_id, map_id=None, rank_id=None):
         "JOIN rank_logs rl ON bl.rank_log_id = rl.id "
         "JOIN _maps m ON rl.map_id = m.id WHERE 1=1"
     )
-    params = []
+    params: list = []
+    if season_id is not None:
+        start, next_start = season_range(season_id)
+        base += " AND substr(bl.id,1,8) >= ? AND substr(bl.id,1,8) < ?"
+        params.extend([start.strftime("%Y%m%d"), next_start.strftime("%Y%m%d")])
     if mode_id is not None:
         base += " AND m.mode_id=?"
         params.append(mode_id)
@@ -77,7 +136,9 @@ def brawler_win_rate(mode_id, map_id=None, rank_id=None):
         params.append(rank_id)
     with sqlite3.connect(DB_PATH) as conn:
         wins = pd.read_sql_query(
-            "SELECT w.win_brawler_id AS brawler_id, COUNT(*) AS wins " + base + " GROUP BY w.win_brawler_id",
+            "SELECT w.win_brawler_id AS brawler_id, COUNT(*) AS wins "
+            + base
+            + " GROUP BY w.win_brawler_id",
             conn,
             params=params,
         )
@@ -95,58 +156,71 @@ def brawler_win_rate(mode_id, map_id=None, rank_id=None):
     df = df.merge(brawlers, left_on="brawler_id", right_on="id").drop("id", axis=1)
     return df.rename(columns={"name_ja": "brawler"}).sort_values("win_rate", ascending=False)
 
-def battle_counts(mode_id, map_id=None, rank_id=None):
+def battle_counts(season_id=None, mode_id=None, map_id=None, rank_id=None):
     """各階層での対戦数を取得する"""
+    if season_id is not None:
+        start, next_start = season_range(season_id)
+        season_cond = "substr(id,1,8) >= ? AND substr(id,1,8) < ?"
+        season_params = [start.strftime("%Y%m%d"), next_start.strftime("%Y%m%d")]
+    else:
+        season_cond = "1=1"
+        season_params = []
+
     with sqlite3.connect(DB_PATH) as conn:
-        overall = conn.execute("SELECT COUNT(*) FROM battle_logs").fetchone()[0]
+        overall = conn.execute(
+            f"SELECT COUNT(*) FROM battle_logs bl WHERE {season_cond}",
+            season_params,
+        ).fetchone()[0]
+
         if mode_id is not None:
             mode = conn.execute(
-                "SELECT COUNT(*) FROM battle_logs bl "
+                f"SELECT COUNT(*) FROM battle_logs bl "
                 "JOIN rank_logs rl ON bl.rank_log_id = rl.id "
-                "JOIN _maps m ON rl.map_id = m.id WHERE m.mode_id=?",
-                (mode_id,),
+                "JOIN _maps m ON rl.map_id = m.id WHERE "
+                f"{season_cond} AND m.mode_id=?",
+                season_params + [mode_id],
             ).fetchone()[0]
         else:
             mode = overall
+
         if map_id is not None:
             map_total = conn.execute(
-                "SELECT COUNT(*) FROM battle_logs bl "
-                "JOIN rank_logs rl ON bl.rank_log_id = rl.id WHERE rl.map_id=?",
-                (map_id,),
+                f"SELECT COUNT(*) FROM battle_logs bl "
+                "JOIN rank_logs rl ON bl.rank_log_id = rl.id WHERE "
+                f"{season_cond} AND rl.map_id=?",
+                season_params + [map_id],
             ).fetchone()[0]
         else:
             map_total = mode
-        if map_id is not None and rank_id is not None:
+
+        if rank_id is not None:
             rank_total = conn.execute(
-                "SELECT COUNT(*) FROM battle_logs bl "
-                "JOIN rank_logs rl ON bl.rank_log_id = rl.id "
-                "WHERE rl.map_id=? AND rl.rank_id=?",
-                (map_id, rank_id),
-            ).fetchone()[0]
-        elif map_id is None and rank_id is not None:
-            rank_total = conn.execute(
-                "SELECT COUNT(*) FROM battle_logs bl "
-                "JOIN rank_logs rl ON bl.rank_log_id = rl.id WHERE rl.rank_id=?",
-                (rank_id,),
+                f"SELECT COUNT(*) FROM battle_logs bl "
+                "JOIN rank_logs rl ON bl.rank_log_id = rl.id WHERE "
+                f"{season_cond} AND rl.rank_id=?",
+                season_params + [rank_id],
             ).fetchone()[0]
         else:
             rank_total = map_total
+
     return {"all": overall, "mode": mode, "map": map_total, "rank": rank_total}
 
-def matchup_rates(map_id, brawler_id):
+def matchup_rates(map_id, brawler_id, season_id=None):
     with sqlite3.connect(DB_PATH) as conn:
-        df = pd.read_sql_query(
-            """
-            SELECT w.win_brawler_id, w.lose_brawler_id, COUNT(*) AS cnt
-            FROM win_lose_logs w
-            JOIN battle_logs bl ON w.battle_log_id = bl.id
-            JOIN rank_logs rl ON bl.rank_log_id = rl.id
-            WHERE rl.map_id=?
-            GROUP BY w.win_brawler_id, w.lose_brawler_id
-            """,
-            conn,
-            params=(map_id,),
+        query = (
+            "SELECT w.win_brawler_id, w.lose_brawler_id, COUNT(*) AS cnt "
+            "FROM win_lose_logs w "
+            "JOIN battle_logs bl ON w.battle_log_id = bl.id "
+            "JOIN rank_logs rl ON bl.rank_log_id = rl.id "
+            "WHERE rl.map_id=?"
         )
+        params: list = [map_id]
+        if season_id is not None:
+            start, next_start = season_range(season_id)
+            query += " AND substr(bl.id,1,8) >= ? AND substr(bl.id,1,8) < ?"
+            params.extend([start.strftime("%Y%m%d"), next_start.strftime("%Y%m%d")])
+        query += " GROUP BY w.win_brawler_id, w.lose_brawler_id"
+        df = pd.read_sql_query(query, conn, params=params)
     wins = (
         df[df["win_brawler_id"] == brawler_id]
         .set_index("lose_brawler_id")["cnt"]
@@ -176,7 +250,14 @@ def main():
     if st_autorefresh:
         st_autorefresh(interval=60 * 1000, key="data_refresh")
 
-    # conn = get_connection()
+    seasons = load_seasons()
+    season_options = ["全体"] + [f"シーズン{s}" for s in seasons]
+    season_name = st.selectbox("シーズン", season_options)
+    if season_name == "全体":
+        season_id = None
+    else:
+        season_id = int(season_name.replace("シーズン", ""))
+
     modes = load_modes()
     mode_options = ["全体"] + modes["name_ja"].tolist()
     mode_name = st.selectbox("モード", mode_options)
@@ -202,20 +283,20 @@ def main():
     else:
         rank_id = int(ranks[ranks["name_ja"] == rank_name]["id"].iloc[0])
 
-    counts = battle_counts(mode_id, map_id, rank_id)
+    counts = battle_counts(season_id, mode_id, map_id, rank_id)
     st.caption(
         f"全体: {counts['all']} / モード: {counts['mode']} / マップ: {counts['map']} / ランク: {counts['rank']}"
     )
 
     st.header("キャラ使用率")
-    usage_df = brawler_usage(mode_id, map_id, rank_id)
+    usage_df = brawler_usage(season_id, mode_id, map_id, rank_id)
     if not usage_df.empty:
         st.bar_chart(usage_df.set_index("brawler")["usage_rate"])
     else:
         st.write("データがありません")
 
     st.header("キャラ勝率")
-    win_df = brawler_win_rate(mode_id, map_id, rank_id)
+    win_df = brawler_win_rate(season_id, mode_id, map_id, rank_id)
     if not win_df.empty:
         st.bar_chart(win_df.set_index("brawler")["win_rate"])
     else:
@@ -227,7 +308,7 @@ def main():
     brawler_name = st.selectbox("キャラ", brawlers["name_ja"])
     brawler_id = int(brawlers[brawlers["name_ja"] == brawler_name]["id"].iloc[0])
     if map_id is not None:
-        match_df = matchup_rates(map_id, brawler_id)
+        match_df = matchup_rates(map_id, brawler_id, season_id)
         if not match_df.empty:
             st.dataframe(match_df)
         else:


### PR DESCRIPTION
## Summary
- add season hierarchy with first-Thursday calculation
- filter usage and win rates by season and add season selector
- document season-based statistics in README

## Testing
- `python -m py_compile dashboard.py`


------
https://chatgpt.com/codex/tasks/task_e_68a844208fe0832bad9612ee141c1c89