### PR TITLE
勝率エクスポートクエリの高速化とインデックスの追加

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -71,3 +71,8 @@ CREATE TABLE IF NOT EXISTS win_lose_logs (
     FOREIGN KEY (lose_brawler_id) REFERENCES brawlers(id),
     FOREIGN KEY (battle_log_id) REFERENCES battle_logs(id)
 );
+
+-- indexes for performance tuning
+CREATE INDEX IF NOT EXISTS idx_battle_logs_rank_log_id ON battle_logs(rank_log_id);
+CREATE INDEX IF NOT EXISTS idx_rank_logs_rank_map ON rank_logs(rank_id, map_id);
+CREATE INDEX IF NOT EXISTS idx_win_lose_logs_battle_log_id ON win_lose_logs(battle_log_id);


### PR DESCRIPTION
## Summary
- export_win_rates.py のSQLを最適化して無駄な全表走査を削除
- スキーマにインデックスを追加して主要テーブルの結合を高速化

## Testing
- `python export_win_rates.py --db brawl_stats.db --output /tmp/win_rates.json` (データベースが壊れているため `file is not a database` エラー)

------
https://chatgpt.com/codex/tasks/task_e_68a9d30630f0832bb0e2ba0060b89711