### PR TITLE
Fix missing join for map filter in battle_counts

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -210,6 +210,7 @@ def battle_counts(season_id=None, rank_id=None, mode_id=None, map_id=None):
             map_total = conn.execute(
                 f"SELECT COUNT(*) FROM battle_logs bl "
                 "JOIN rank_logs rl ON bl.rank_log_id = rl.id "
+                "JOIN _maps m ON rl.map_id = m.id "
                 f"WHERE {cond_map}",
                 params_map,
             ).fetchone()[0]


### PR DESCRIPTION
## Summary
- join `_maps` table when counting battles by map to avoid `m.mode_id` column error

## Testing
- `python -m py_compile dashboard.py`
- `pip install pandas` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a9db5fd9c8832b9008d33da1ae3557