### PR TITLE
Fix Decimal and float mixing in win rate calculation

### DIFF
--- a/export_win_rates.py
+++ b/export_win_rates.py
@@ -77,8 +77,13 @@ def compute_win_rates(rows: List[tuple]) -> Dict[int, Dict[int, float]]:
         lambda: defaultdict(lambda: {"wins": 0.0, "games": 0.0})
     )
     for map_id, brawler_id, wins, losses in rows:
-        stats[map_id][brawler_id]["wins"] += wins
-        stats[map_id][brawler_id]["games"] += wins + losses
+        # MySQLコネクタは SUM 関数の結果を decimal.Decimal で返すため
+        # float と混在すると演算で TypeError が発生する。
+        # ここではすべての値を明示的に float に変換して集計する。
+        wins_f = float(wins)
+        losses_f = float(losses)
+        stats[map_id][brawler_id]["wins"] += wins_f
+        stats[map_id][brawler_id]["games"] += wins_f + losses_f
 
     logging.info("勝率を計算しています...")
     results: Dict[int, Dict[int, float]] = {}


### PR DESCRIPTION
## Summary
- convert MySQL Decimal results to float during win rate aggregation

## Testing
- `python -m py_compile export_win_rates.py`


------
https://chatgpt.com/codex/tasks/task_e_68b060551a78832baa41f4d9f19d228d