### PR TITLE
Avoid unread result error when fetching next player

### DIFF
--- a/fetch_battlelog.py
+++ b/fetch_battlelog.py
@@ -311,21 +311,24 @@ def main() -> None:
                     cur = conn.cursor()
                     seventy_two_hours_ago = datetime.now(JST) - timedelta(hours=ACQ_CYCLE_TIME)
                     
-                    current_tag = cur.execute(
+                    cur.execute(
                         "SELECT tag FROM players WHERE last_fetched < %s ORDER BY last_fetched ASC LIMIT 1",
-                        (seventy_two_hours_ago,)
-                    ).fetchone()[0]
-                    
+                        (seventy_two_hours_ago,),
+                    )
+                    row = cur.fetchone()
+                    current_tag = row[0] if row else None
+
                     if not current_tag:
                         print("対象プレイヤーがいません")
                         break
 
                     fetch_battle_logs(current_tag, api_key, conn)
 
-                    rest = cur.execute(
+                    cur.execute(
                         "SELECT COUNT(*) FROM players WHERE last_fetched < %s",
-                        (seventy_two_hours_ago,)
-                    ).fetchone()[0]
+                        (seventy_two_hours_ago,),
+                    )
+                    rest = cur.fetchone()[0]
                     if rest == 0:
                         print("全てのプレイヤーを集計しました")
                         break


### PR DESCRIPTION
## Summary
- ensure SELECT results are fully fetched before issuing new queries in fetch loop

## Testing
- `python -m py_compile fetch_battlelog.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0633535d8832ba18bfc0247cf9ee9