### PR TITLE
fix: use %s placeholder for deleting players

### DIFF
--- a/fetch_battlelog.py
+++ b/fetch_battlelog.py
@@ -211,7 +211,7 @@ def fetch_battle_logs(player_tag: str, api_key: str, conn) -> set[str]:
                     my_side_idx = side_idx
                     resultLog.result = result
                     if trophies < 7:
-                        cur.execute("DELETE FROM players WHERE tag=?", (player_tag,))
+                        cur.execute("DELETE FROM players WHERE tag=%s", (player_tag,))
                         print(f"プレイヤー削除！:{p_tag}")
                 if 18 < trophies <= 22:
                     cur.execute("INSERT IGNORE INTO players(tag) VALUES (%s)", (p_tag,))


### PR DESCRIPTION
## Summary
- fix incorrect sqlite placeholder in DELETE query

## Testing
- `python -m py_compile fetch_battlelog.py`


------
https://chatgpt.com/codex/tasks/task_e_68b27ba07af0832b8625b6459ea3376e