### PR TITLE
pandas の SQL 警告解消のため SQLAlchemy エンジンを導入

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 scipy
+sqlalchemy

--- a/src/db.py
+++ b/src/db.py
@@ -1,6 +1,7 @@
 import os
 import mysql.connector
 from dotenv import load_dotenv
+from sqlalchemy import create_engine
 
 def get_connection():
     load_dotenv(dotenv_path=".env.local")
@@ -11,3 +12,13 @@ def get_connection():
         database=os.getenv("MYSQL_DB", "brawl_stats"),
         autocommit=True,
     )
+
+
+def get_engine():
+    load_dotenv(dotenv_path=".env.local")
+    user = os.getenv("MYSQL_USER", "root")
+    password = os.getenv("MYSQL_PASSWORD", "")
+    host = os.getenv("MYSQL_HOST", "localhost")
+    database = os.getenv("MYSQL_DB", "brawl_stats")
+    url = f"mysql+mysqlconnector://{user}:{password}@{host}/{database}"
+    return create_engine(url)


### PR DESCRIPTION
## 概要
- pandas での SQL 実行時に出ていた警告を解消するため、SQLAlchemy エンジンを追加
- dashboard の各種クエリを SQLAlchemy 経由で実行するよう修正
- requirements に sqlalchemy を追加

## テスト
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba82861ac0832b872e325bdf75c471