### PR TITLE
Add rank match count export

### DIFF
--- a/scripts/run_pipeline.sh
+++ b/scripts/run_pipeline.sh
@@ -13,6 +13,7 @@ COPY_PATH="/lib/map-meta/"
 COPY_PATH2="/public/"
 WIN_RATE_FILE_NAME="win_rates.json"
 STAR_RATE_FILE_NAME="star_rates.json"
+RANK_MATCH_COUNT_FILE_NAME="rank_match_counts.json"
 PAIR_STATS_DIR_NAME="pair_stats"
 TRIO_STATS_DIR_NAME="trio_stats"
 PID_FILE="${BASE_DIR}/.${SCRIPT_NAME}.pid"
@@ -200,6 +201,7 @@ main() {
     local end_date=$(TZ=Asia/Tokyo date +%Y%m%d%H%M)
     local output_file="${OUTPUT_DIR}/${WIN_RATE_FILE_NAME}"
     local star_output_file="${OUTPUT_DIR}/${STAR_RATE_FILE_NAME}"
+    local rank_match_output_file="${OUTPUT_DIR}/${RANK_MATCH_COUNT_FILE_NAME}"
     local pair_output_dir="${OUTPUT_DIR}/${PAIR_STATS_DIR_NAME}"
     local trio_output_dir="${OUTPUT_DIR}/${TRIO_STATS_DIR_NAME}"
     
@@ -250,6 +252,24 @@ main() {
         log_warn "出力ファイルが空です: $star_output_file"
     fi
 
+    # ダイヤモンド以上のランクマッチ数を出力
+    log_info "ランクマッチ数データをエクスポートしています"
+    if ! /Users/shunsukeiwao/develop/brawl_stars_gachibattle_statistics/venv/bin/python -m src.export_rank_match_counts --output "$rank_match_output_file"; then
+        log_error "ランクマッチ数データのエクスポートに失敗しました"
+        exit 1
+    fi
+
+    if [[ ! -f "$rank_match_output_file" ]]; then
+        log_error "出力ファイルが見つかりません: $rank_match_output_file"
+        exit 1
+    fi
+
+    log_info "出力ファイルを生成しました: $rank_match_output_file"
+
+    if [[ ! -s "$rank_match_output_file" ]]; then
+        log_warn "出力ファイルが空です: $rank_match_output_file"
+    fi
+
     # ペアデータを出力
     log_info "ペアデータをエクスポートしています"
     if ! /Users/shunsukeiwao/develop/brawl_stars_gachibattle_statistics/venv/bin/python -m src.export_pair_stats --output-dir "$pair_output_dir"; then
@@ -289,6 +309,7 @@ main() {
     # アプリディレクトリへのコピー
     local destination_win_rate="${APP_DIR}${COPY_PATH}${WIN_RATE_FILE_NAME}"
     local destination_star_rate="${APP_DIR}${COPY_PATH}${STAR_RATE_FILE_NAME}"
+    local destination_rank_match="${APP_DIR}${COPY_PATH}${RANK_MATCH_COUNT_FILE_NAME}"
     local destination_pair_stats="${APP_DIR}${COPY_PATH2}${PAIR_STATS_DIR_NAME}"
     local destination_trio_stats="${APP_DIR}${COPY_PATH}${TRIO_STATS_DIR_NAME}"
     log_info "ファイルをアプリケーションディレクトリにコピーしています"
@@ -300,6 +321,11 @@ main() {
 
     if ! cp "$star_output_file" "$destination_star_rate"; then
         log_error "star_rateファイルのコピーに失敗しました"
+        exit 1
+    fi
+
+    if ! cp "$rank_match_output_file" "$destination_rank_match"; then
+        log_error "rank_matchファイルのコピーに失敗しました"
         exit 1
     fi
 

--- a/src/export_rank_match_counts.py
+++ b/src/export_rank_match_counts.py
@@ -1,0 +1,94 @@
+"""ランクごとのランクマッチ数をJSONとして出力するスクリプト."""
+
+import argparse
+import json
+import logging
+from typing import List, TypedDict
+
+import mysql.connector
+
+from .db import get_connection
+from .logging_config import setup_logging
+
+DIAMOND_RANK_ID = 4
+
+
+class RankMatchCount(TypedDict):
+    """ランク別のランクマッチ集計結果."""
+
+    rank_id: int
+    name: str
+    name_ja: str
+    rank_log_count: int
+
+
+setup_logging()
+
+
+def fetch_rank_match_counts(conn) -> List[RankMatchCount]:
+    """ダイヤモンド以上のランクごとのランクマッチ数を取得する."""
+
+    query = """
+        SELECT
+            r.id AS rank_id,
+            r.name,
+            r.name_ja,
+            COUNT(rl.id) AS rank_log_count
+        FROM _ranks r
+        LEFT JOIN rank_logs rl ON r.id = rl.rank_id
+        WHERE r.id >= %s
+        GROUP BY r.id, r.name, r.name_ja
+        ORDER BY r.id
+    """
+
+    cursor = conn.cursor()
+    cursor.execute(query, (DIAMOND_RANK_ID,))
+    results: List[RankMatchCount] = []
+    for rank_id, name, name_ja, rank_log_count in cursor.fetchall():
+        results.append(
+            RankMatchCount(
+                rank_id=int(rank_id),
+                name=str(name),
+                name_ja=str(name_ja),
+                rank_log_count=int(rank_log_count),
+            )
+        )
+    return results
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="ダイヤモンド以上のランクマッチ数をJSONとして出力"
+    )
+    parser.add_argument(
+        "--output",
+        default="rank_match_counts.json",
+        help="出力先JSONファイル",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+
+    logging.info("データベースに接続しています")
+    try:
+        conn = get_connection()
+    except mysql.connector.Error as exc:
+        raise SystemExit(f"データベースに接続できません: {exc}")
+
+    try:
+        logging.info("ランクマッチ数を取得しています...")
+        results = fetch_rank_match_counts(conn)
+        logging.info("%d 件のランク情報を取得しました", len(results))
+    except mysql.connector.Error as exc:
+        raise SystemExit(f"クエリの実行に失敗しました: {exc}")
+    finally:
+        conn.close()
+
+    logging.info("JSONファイルに書き込んでいます: %s", args.output)
+    with open(args.output, "w", encoding="utf-8") as fp:
+        json.dump(results, fp, ensure_ascii=False, indent=2)
+    logging.info("JSON出力が完了しました")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a script that exports diamond and higher rank match counts to JSON
- run the new exporter from the pipeline and copy the file to the app directory

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68cc9a482720832bb37fb02e0b57dd64