### PR TITLE
Switch to shared 0.9 confidence level and prune low-sample 3v3 stats

### DIFF
--- a/src/export_trio_stats.py
+++ b/src/export_trio_stats.py
@@ -13,7 +13,7 @@ import mysql.connector
 
 from .db import get_connection
 from .logging_config import setup_logging
-from .settings import DATA_RETENTION_DAYS
+from .settings import CONFIDENCE_LEVEL, DATA_RETENTION_DAYS
 from .trio_stats import compute_trio_scores, fetch_trio_rows
 
 setup_logging()
@@ -72,7 +72,11 @@ def main() -> None:
         conn.close()
 
     logging.info("勝率指標を計算しています")
-    results = compute_trio_scores(rows, group_by_rank=False)
+    results = compute_trio_scores(
+        rows,
+        group_by_rank=False,
+        confidence=CONFIDENCE_LEVEL,
+    )
     output_dir = Path(args.output_dir)
     logging.info("JSONを出力しています: %s", output_dir)
     export_trio_json(results, output_dir)

--- a/src/settings.py
+++ b/src/settings.py
@@ -13,6 +13,7 @@ DEFAULT_ENV_FILE = BASE_DIR / "config" / "settings.env"
 LOCAL_ENV_FILE = BASE_DIR / ".env.local"
 _DEFAULT_RETENTION_DAYS = 30
 _DEFAULT_MIN_RANK_ID = 4
+_DEFAULT_CONFIDENCE_LEVEL = 0.9
 
 
 @lru_cache(maxsize=1)
@@ -36,5 +37,20 @@ def _get_int_env(name: str, default: int) -> int:
         ) from exc
 
 
+def _get_float_env(name: str, default: float) -> float:
+    """環境変数を浮動小数点数として取得する。"""
+    load_environment()
+    value = os.getenv(name)
+    if value in (None, ""):
+        return default
+    try:
+        return float(value)
+    except ValueError as exc:  # pragma: no cover - エラーハンドリングのための保険
+        raise ValueError(
+            f"環境変数 {name} は浮動小数点数である必要があります (現在の値: {value})"
+        ) from exc
+
+
 DATA_RETENTION_DAYS = _get_int_env("DATA_RETENTION_DAYS", _DEFAULT_RETENTION_DAYS)
 MIN_RANK_ID = _get_int_env("MIN_RANK_ID", _DEFAULT_MIN_RANK_ID)
+CONFIDENCE_LEVEL = _get_float_env("CONFIDENCE_LEVEL", _DEFAULT_CONFIDENCE_LEVEL)

--- a/src/trio_stats.py
+++ b/src/trio_stats.py
@@ -6,12 +6,12 @@ from typing import Dict, Iterable, List, Optional, Tuple
 
 from scipy.stats import beta
 
-from .settings import MIN_RANK_ID
+from .settings import CONFIDENCE_LEVEL, MIN_RANK_ID
 
 TrioRow = Tuple[int, int, int, int, int, int, float, float]
 
 
-def beta_lcb(alpha: float, beta_param: float, confidence: float = 0.95) -> float:
+def beta_lcb(alpha: float, beta_param: float, confidence: float = CONFIDENCE_LEVEL) -> float:
     """Beta分布に基づく下側信頼限界を計算する."""
     return float(beta.ppf(1 - confidence, alpha, beta_param))
 
@@ -141,7 +141,7 @@ def compute_trio_scores(
     *,
     group_by_rank: bool = True,
     min_games: int = 0,
-    confidence: float = 0.95,
+    confidence: float = CONFIDENCE_LEVEL,
 ) -> Dict[int, Dict[Optional[int], List[Dict[str, object]]]]:
     """トリオ勝率の指標値を計算する."""
 


### PR DESCRIPTION
## Summary
- add a shared `CONFIDENCE_LEVEL` setting (default 0.9) and apply it across trio, pair, and tag win-rate exporters
- filter 3v3 matchups with three games or fewer while emitting simplified JSON records
- refresh related documentation to match the adjusted confidence level

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68ce5140a978832bbfec8b6bbfa7218a