### PR TITLE
Adjust statistics exports to include match counts and usage data

### DIFF
--- a/src/export_3v3_win_rates.py
+++ b/src/export_3v3_win_rates.py
@@ -170,13 +170,17 @@ def compute_matchup_scores(
             record = {
                 "win_brawlers": list(win_team),
                 "lose_brawlers": list(lose_team),
+                "games": int(round(games)),
                 "win_rate": wins_val / games if games > 0 else 0.0,
                 "win_rate_lcb": lcb,
             }
-            records.append((record, games))
+            records.append(record)
 
-        records.sort(key=lambda item: (item[0]["win_rate_lcb"], item[1]), reverse=True)
-        results[map_id] = [record for record, _ in records]
+        records.sort(
+            key=lambda item: (item["win_rate_lcb"], item["games"]),
+            reverse=True,
+        )
+        results[map_id] = records
 
     return results
 

--- a/src/export_star_rates.py
+++ b/src/export_star_rates.py
@@ -1,4 +1,4 @@
-"""スター取得率をマップ・ランク・キャラ別に集計してJSON出力するスクリプト."""
+"""スター取得率をマップ・キャラ別に集計してJSON出力するスクリプト."""
 
 import argparse
 import json
@@ -10,42 +10,75 @@ import mysql.connector
 
 from .db import get_connection
 from .logging_config import setup_logging
-from .settings import DATA_RETENTION_DAYS
+from .settings import DATA_RETENTION_DAYS, MIN_RANK_ID
 
 setup_logging()
 
 
-def fetch_star_rows(conn, since: str) -> List[Tuple[int, int, int, int]]:
+def fetch_star_rows(conn, since: str) -> List[Tuple[int, int, int, int, int]]:
     cursor = conn.cursor()
     sql = """
     WITH recent_ranks AS (
         SELECT rl.id, rl.map_id
         FROM rank_logs rl
-        WHERE SUBSTRING(rl.id, 1, 8) >= %s
+        WHERE rl.rank_id >= %s AND SUBSTRING(rl.id, 1, 8) >= %s
     ), totals AS (
-        SELECT map_id, COUNT(*) AS total_matches
+        SELECT map_id, COUNT(*) AS total_rank_logs
         FROM recent_ranks
         GROUP BY map_id
+    ), participants AS (
+        SELECT DISTINCT rr.id AS rank_log_id, wl.win_brawler_id AS brawler_id
+        FROM win_lose_logs wl
+        JOIN battle_logs bl ON wl.battle_log_id = bl.id
+        JOIN recent_ranks rr ON bl.rank_log_id = rr.id
+        UNION
+        SELECT DISTINCT rr.id AS rank_log_id, wl.lose_brawler_id AS brawler_id
+        FROM win_lose_logs wl
+        JOIN battle_logs bl ON wl.battle_log_id = bl.id
+        JOIN recent_ranks rr ON bl.rank_log_id = rr.id
+    ), usage AS (
+        SELECT rr.map_id,
+               p.brawler_id,
+               COUNT(DISTINCT p.rank_log_id) AS rank_logs
+        FROM participants p
+        JOIN recent_ranks rr ON p.rank_log_id = rr.id
+        GROUP BY rr.map_id, p.brawler_id
     ), star_counts AS (
-        SELECT rr.map_id, rsl.star_brawler_id, COUNT(*) AS star_count
-        FROM recent_ranks rr
-        JOIN rank_star_logs rsl ON rr.id = rsl.rank_log_id
+        SELECT rr.map_id, rsl.star_brawler_id AS brawler_id, COUNT(*) AS star_count
+        FROM rank_star_logs rsl
+        JOIN recent_ranks rr ON rsl.rank_log_id = rr.id
         GROUP BY rr.map_id, rsl.star_brawler_id
     )
-    SELECT sc.map_id, sc.star_brawler_id, sc.star_count, t.total_matches
-    FROM star_counts sc
-    JOIN totals t ON sc.map_id = t.map_id
+    SELECT u.map_id,
+           u.brawler_id,
+           u.rank_logs,
+           COALESCE(sc.star_count, 0) AS star_count,
+           t.total_rank_logs
+    FROM usage u
+    JOIN totals t ON u.map_id = t.map_id
+    LEFT JOIN star_counts sc
+        ON u.map_id = sc.map_id AND u.brawler_id = sc.brawler_id
     """
-    cursor.execute(sql, (since,))
+    cursor.execute(sql, (MIN_RANK_ID, since))
     return cursor.fetchall()
 
 
-def compute_star_rates(rows: List[Tuple[int, int, int, int]]) -> Dict[int, Dict[int, float]]:
-    results: Dict[int, Dict[int, float]] = {}
-    for map_id, brawler_id, star_count, total_matches in rows:
+def compute_star_rates(
+    rows: List[Tuple[int, int, int, int, int]]
+) -> Dict[int, Dict[int, Dict[str, float]]]:
+    results: Dict[int, Dict[int, Dict[str, float]]] = {}
+    for map_id, brawler_id, rank_logs, star_count, total_rank_logs in rows:
         map_stats = results.setdefault(map_id, {})
-        rate = star_count / total_matches if total_matches else 0.0
-        map_stats[brawler_id] = rate
+        if rank_logs <= 0:
+            star_rate = 0.0
+        else:
+            star_rate = star_count / rank_logs
+        usage_rate = rank_logs / total_rank_logs if total_rank_logs else 0.0
+        map_stats[brawler_id] = {
+            "rank_logs": int(rank_logs),
+            "star_rate": star_rate,
+            "usage_rate": usage_rate,
+        }
     return results
 
 

--- a/src/export_trio_stats.py
+++ b/src/export_trio_stats.py
@@ -34,6 +34,7 @@ def export_trio_json(
         simplified = [
             {
                 "brawlers": combo["brawlers"],
+                "games": combo["games"],
                 "win_rate_lcb": combo["win_rate_lcb"],
             }
             for combo in combos


### PR DESCRIPTION
## Summary
- update win rate export to count battle logs per brawler and emit games plus LCB win rate
- enrich star rate export with rank log counts, star probability, and usage rate filtered by retention settings
- include match counts in pair, trio, and 3v3 statistics outputs while preserving LCB calculations

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68ceb6fa90f8832b913e19e7ba8de720