### PR TITLE
Refactor stats exports to reuse shared dataset and orchestrator

### DIFF
--- a/scripts/run_pipeline.sh
+++ b/scripts/run_pipeline.sh
@@ -217,30 +217,29 @@ main() {
     fi
 
     # 勝率データを出力
-    log_info "勝率データをエクスポートしています"
-    if ! /Users/shunsukeiwao/develop/brawl_stars_gachibattle_statistics/venv/bin/python -m src.export_win_rates --output "$output_file"; then
-        log_error "勝率データのエクスポートに失敗しました"
+    log_info "統計データをまとめてエクスポートしています"
+    if ! /Users/shunsukeiwao/develop/brawl_stars_gachibattle_statistics/venv/bin/python \
+        -m src.export_all_stats \
+        --output-root "$OUTPUT_DIR" \
+        --win-rate-filename "$WIN_RATE_FILE_NAME" \
+        --star-rate-filename "$STAR_RATE_FILE_NAME" \
+        --rank-match-count-filename "$RANK_MATCH_COUNT_FILE_NAME" \
+        --pair-dir-name "$PAIR_STATS_DIR_NAME" \
+        --trio-dir-name "$TRIO_STATS_DIR_NAME" \
+        --three-vs-three-dir-name "$THREE_VS_THREE_STATS_DIR_NAME"; then
+        log_error "統計データのエクスポートに失敗しました"
         exit 1
     fi
-    
-    # 出力ファイルの存在確認
+
     if [[ ! -f "$output_file" ]]; then
         log_error "出力ファイルが見つかりません: $output_file"
         exit 1
     fi
-    
+
     log_info "出力ファイルを生成しました: $output_file"
 
-    # ファイルサイズをチェック（空ファイルかどうか）
     if [[ ! -s "$output_file" ]]; then
         log_warn "出力ファイルが空です: $output_file"
-    fi
-
-    # スターデータを出力
-    log_info "スター取得データをエクスポートしています"
-    if ! /Users/shunsukeiwao/develop/brawl_stars_gachibattle_statistics/venv/bin/python -m src.export_star_rates --output "$star_output_file"; then
-        log_error "スター取得データのエクスポートに失敗しました"
-        exit 1
     fi
 
     if [[ ! -f "$star_output_file" ]]; then
@@ -254,13 +253,6 @@ main() {
         log_warn "出力ファイルが空です: $star_output_file"
     fi
 
-    # ダイヤモンド以上のランクマッチ数を出力
-    log_info "ランクマッチ数データをエクスポートしています"
-    if ! /Users/shunsukeiwao/develop/brawl_stars_gachibattle_statistics/venv/bin/python -m src.export_rank_match_counts --output "$rank_match_output_file"; then
-        log_error "ランクマッチ数データのエクスポートに失敗しました"
-        exit 1
-    fi
-
     if [[ ! -f "$rank_match_output_file" ]]; then
         log_error "出力ファイルが見つかりません: $rank_match_output_file"
         exit 1
@@ -272,13 +264,6 @@ main() {
         log_warn "出力ファイルが空です: $rank_match_output_file"
     fi
 
-    # ペアデータを出力
-    log_info "ペアデータをエクスポートしています"
-    if ! /Users/shunsukeiwao/develop/brawl_stars_gachibattle_statistics/venv/bin/python -m src.export_pair_stats --output-dir "$pair_output_dir"; then
-        log_error "ペアデータのエクスポートに失敗しました"
-        exit 1
-    fi
-
     if [[ ! -d "$pair_output_dir" ]]; then
         log_error "出力ディレクトリが見つかりません: $pair_output_dir"
         exit 1
@@ -287,14 +272,7 @@ main() {
     log_info "出力ディレクトリを生成しました: $pair_output_dir"
 
     if [[ -z $(find "$pair_output_dir" -type f -name '*.json') ]]; then
-        log_warn "出力ディレクトリが空です: $pair_output_dir"
-    fi
-
-    # トリオデータを出力
-    log_info "トリオデータをエクスポートしています"
-    if ! /Users/shunsukeiwao/develop/brawl_stars_gachibattle_statistics/venv/bin/python -m src.export_trio_stats --output-dir "$trio_output_dir"; then
-        log_error "トリオデータのエクスポートに失敗しました"
-        exit 1
+        log_warn "出力ディクトリが空です: $pair_output_dir"
     fi
 
     if [[ ! -d "$trio_output_dir" ]]; then
@@ -308,13 +286,6 @@ main() {
         log_warn "出力ディレクトリが空です: $trio_output_dir"
     fi
 
-    # 3対3データを出力
-    log_info "3対3データをエクスポートしています"
-    if ! /Users/shunsukeiwao/develop/brawl_stars_gachibattle_statistics/venv/bin/python -m src.export_3v3_win_rates --output-dir "$three_vs_three_output_dir"; then
-        log_error "3対3データのエクスポートに失敗しました"
-        exit 1
-    fi
-
     if [[ ! -d "$three_vs_three_output_dir" ]]; then
         log_error "出力ディレクトリが見つかりません: $three_vs_three_output_dir"
         exit 1
@@ -325,7 +296,6 @@ main() {
     if [[ -z $(find "$three_vs_three_output_dir" -type f -name '*.json') ]]; then
         log_warn "出力ディレクトリが空です: $three_vs_three_output_dir"
     fi
-
     # アプリディレクトリへのコピー
     local destination_win_rate="${APP_DIR}${COPY_PATH}${WIN_RATE_FILE_NAME}"
     local destination_star_rate="${APP_DIR}${COPY_PATH}${STAR_RATE_FILE_NAME}"

--- a/src/export_all_stats.py
+++ b/src/export_all_stats.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import shutil
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Callable, Dict
+
+import mysql.connector
+
+from .db import get_connection
+from .export_3v3_win_rates import (
+    compute_matchup_scores as compute_three_vs_three_scores,
+    export_matchup_json,
+    fetch_matchup_rows as fetch_three_vs_three_rows,
+)
+from .export_pair_stats import (
+    compute_pair_rates,
+    fetch_matchup_stats as fetch_pair_matchup_stats,
+    fetch_synergy_stats as fetch_pair_synergy_stats,
+)
+from .export_star_rates import compute_star_rates, fetch_star_rows
+from .export_trio_stats import export_trio_json
+from .export_win_rates import compute_win_rates, fetch_stats as fetch_win_rate_rows
+from .export_rank_match_counts import fetch_rank_match_counts
+from .logging_config import setup_logging
+from .settings import CONFIDENCE_LEVEL, DATA_RETENTION_DAYS
+from .stats_loader import load_recent_ranked_battles
+from .trio_stats import compute_trio_scores, fetch_trio_rows
+
+setup_logging()
+JST = timezone(timedelta(hours=9))
+
+
+def _write_json(path: Path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as fp:
+        json.dump(data, fp, ensure_ascii=False, indent=2)
+
+
+def _export_win_rates(dataset, output_path: Path) -> None:
+    rows = fetch_win_rate_rows(dataset)
+    stats = compute_win_rates(rows, confidence=CONFIDENCE_LEVEL)
+    _write_json(output_path, stats)
+
+
+def _export_star_rates(dataset, output_path: Path) -> None:
+    rows = fetch_star_rows(dataset)
+    stats = compute_star_rates(rows)
+    _write_json(output_path, stats)
+
+
+def _export_pair_stats(dataset, output_dir: Path) -> None:
+    matchup_rows = fetch_pair_matchup_stats(dataset)
+    synergy_rows = fetch_pair_synergy_stats(dataset)
+    matchup_result = compute_pair_rates(
+        matchup_rows, symmetrical=False, confidence=CONFIDENCE_LEVEL
+    )
+    synergy_result = compute_pair_rates(
+        synergy_rows, symmetrical=True, confidence=CONFIDENCE_LEVEL
+    )
+    result = {"matchup": matchup_result, "synergy": synergy_result}
+
+    if output_dir.exists():
+        shutil.rmtree(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    for kind, maps in result.items():
+        kind_dir = output_dir / kind
+        kind_dir.mkdir(parents=True, exist_ok=True)
+        for map_id, data in maps.items():
+            out_file = kind_dir / f"{map_id}.json"
+            _write_json(out_file, data)
+
+
+def _export_trio_stats(dataset, output_dir: Path, since: str) -> None:
+    rows = fetch_trio_rows(dataset=dataset, since=since)
+    results = compute_trio_scores(
+        rows,
+        group_by_rank=False,
+        confidence=CONFIDENCE_LEVEL,
+    )
+    export_trio_json(results, output_dir)
+
+
+def _export_three_vs_three_stats(
+    dataset, output_dir: Path, min_games: int
+) -> None:
+    rows = fetch_three_vs_three_rows(dataset)
+    results = compute_three_vs_three_scores(
+        rows,
+        min_games=min_games,
+        confidence=CONFIDENCE_LEVEL,
+    )
+    export_matchup_json(results, output_dir)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="統計出力をまとめて実行")
+    parser.add_argument(
+        "--output-root",
+        default="data/output",
+        help="統計ファイルを配置するルートディレクトリ",
+    )
+    parser.add_argument(
+        "--win-rate-filename",
+        default="win_rates.json",
+        help="勝率統計のファイル名",
+    )
+    parser.add_argument(
+        "--star-rate-filename",
+        default="star_rates.json",
+        help="スター取得率統計のファイル名",
+    )
+    parser.add_argument(
+        "--rank-match-count-filename",
+        default="rank_match_counts.json",
+        help="ランクマッチ数統計のファイル名",
+    )
+    parser.add_argument(
+        "--pair-dir-name",
+        default="pair_stats",
+        help="ペア統計のディレクトリ名",
+    )
+    parser.add_argument(
+        "--trio-dir-name",
+        default="trio_stats",
+        help="トリオ統計のディレクトリ名",
+    )
+    parser.add_argument(
+        "--three-vs-three-dir-name",
+        default="three_vs_three_stats",
+        help="3対3統計のディレクトリ名",
+    )
+    parser.add_argument(
+        "--three-vs-three-min-games",
+        type=int,
+        default=4,
+        help="3対3統計で採用する最低試合数",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+
+    output_root = Path(args.output_root)
+    output_root.mkdir(parents=True, exist_ok=True)
+
+    jst_now = datetime.now(JST)
+    since = (jst_now - timedelta(days=DATA_RETENTION_DAYS)).strftime("%Y%m%d")
+    logging.info("統計対象期間（日数）: %d", DATA_RETENTION_DAYS)
+
+    logging.info("データベースに接続しています")
+    try:
+        conn = get_connection()
+    except mysql.connector.Error as exc:  # pragma: no cover - DB接続エラー
+        raise SystemExit(f"データベースに接続できません: {exc}")
+
+    try:
+        logging.info("共通データセットを読み込んでいます...")
+        dataset = load_recent_ranked_battles(conn, since)
+        logging.info("ランクマッチ数を取得しています...")
+        rank_match_counts = fetch_rank_match_counts(conn)
+    except mysql.connector.Error as exc:  # pragma: no cover - クエリエラー
+        raise SystemExit(f"クエリの実行に失敗しました: {exc}")
+    finally:
+        conn.close()
+
+    win_rate_path = output_root / args.win_rate_filename
+    star_rate_path = output_root / args.star_rate_filename
+    rank_match_path = output_root / args.rank_match_count_filename
+    pair_dir = output_root / args.pair_dir_name
+    trio_dir = output_root / args.trio_dir_name
+    three_vs_three_dir = output_root / args.three_vs_three_dir_name
+
+    tasks: Dict[str, Callable[[], None]] = {
+        "win_rates": lambda: _export_win_rates(dataset, win_rate_path),
+        "star_rates": lambda: _export_star_rates(dataset, star_rate_path),
+        "pair_stats": lambda: _export_pair_stats(dataset, pair_dir),
+        "trio_stats": lambda: _export_trio_stats(dataset, trio_dir, since),
+        "three_vs_three": lambda: _export_three_vs_three_stats(
+            dataset, three_vs_three_dir, args.three_vs_three_min_games
+        ),
+    }
+
+    logging.info("統計出力を実行しています")
+    with ThreadPoolExecutor(max_workers=len(tasks)) as executor:
+        future_to_name = {executor.submit(func): name for name, func in tasks.items()}
+        for future in as_completed(future_to_name):
+            name = future_to_name[future]
+            try:
+                future.result()
+                logging.info("%s の出力が完了しました", name)
+            except Exception:  # pragma: no cover - 実行時エラーはそのまま伝搬
+                logging.exception("%s の出力中にエラーが発生しました", name)
+                raise
+
+    logging.info("ランクマッチ数を出力しています: %s", rank_match_path)
+    _write_json(rank_match_path, rank_match_counts)
+    logging.info("すべての統計出力が完了しました")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/src/export_trio_stats.py
+++ b/src/export_trio_stats.py
@@ -14,6 +14,7 @@ import mysql.connector
 from .db import get_connection
 from .logging_config import setup_logging
 from .settings import CONFIDENCE_LEVEL, DATA_RETENTION_DAYS
+from .stats_loader import load_recent_ranked_battles
 from .trio_stats import compute_trio_scores, fetch_trio_rows
 
 setup_logging()
@@ -65,7 +66,8 @@ def main() -> None:
 
     try:
         logging.info("トリオ編成データを取得しています...")
-        rows = fetch_trio_rows(conn, since=since)
+        dataset = load_recent_ranked_battles(conn, since)
+        rows = fetch_trio_rows(dataset=dataset, since=since)
         logging.info("%d 行のトリオデータを取得", len(rows))
     except mysql.connector.Error as exc:  # pragma: no cover - クエリエラー
         raise SystemExit(f"クエリの実行に失敗しました: {exc}")

--- a/src/stats_loader.py
+++ b/src/stats_loader.py
@@ -1,0 +1,178 @@
+"""統計処理で共通利用するランクマッチデータの読み込みユーティリティ."""
+
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, Optional, Set, Tuple
+
+from .settings import MIN_RANK_ID
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class RankLogEntry:
+    """ランクログ1件分のメタデータ."""
+
+    id: int
+    map_id: int
+    rank_id: int
+    mode_id: Optional[int]
+    date_key: str
+
+
+@dataclass(frozen=True)
+class RankedBattle:
+    """1試合分の勝敗情報."""
+
+    battle_log_id: int
+    rank_log_id: int
+    map_id: int
+    rank_id: int
+    mode_id: Optional[int]
+    win_brawlers: Tuple[int, ...]
+    lose_brawlers: Tuple[int, ...]
+
+
+@dataclass
+class StatsDataset:
+    """統計エクスポートで使い回すデータセット."""
+
+    rank_logs: Dict[int, RankLogEntry]
+    battles: List[RankedBattle]
+    star_logs: List[Tuple[int, int]]
+    _participants_cache: Optional[Dict[int, Set[int]]] = field(
+        default=None, init=False, repr=False
+    )
+
+    def iter_ranked_battles(self) -> Iterable[RankedBattle]:
+        """読みやすい名前のイテレータを提供."""
+
+        return iter(self.battles)
+
+    def participants_by_rank_log(self) -> Dict[int, Set[int]]:
+        """ランクログIDごとの参加キャラクター集合を取得する."""
+
+        if self._participants_cache is None:
+            participants: Dict[int, Set[int]] = defaultdict(set)
+            for battle in self.battles:
+                if battle.win_brawlers:
+                    participants[battle.rank_log_id].update(battle.win_brawlers)
+                if battle.lose_brawlers:
+                    participants[battle.rank_log_id].update(battle.lose_brawlers)
+            self._participants_cache = {k: set(v) for k, v in participants.items()}
+        return self._participants_cache
+
+
+def load_recent_ranked_battles(conn, since: str) -> StatsDataset:
+    """直近期間のランクマッチ関連データをまとめて読み込む."""
+
+    cursor = conn.cursor()
+
+    logger.info("ランクログ情報を読み込んでいます")
+    rank_logs: Dict[int, RankLogEntry] = {}
+    cursor.execute(
+        """
+        SELECT rl.id, rl.map_id, rl.rank_id, m.mode_id
+        FROM rank_logs rl
+        LEFT JOIN _maps m ON rl.map_id = m.id
+        WHERE rl.rank_id >= %s AND SUBSTRING(rl.id, 1, 8) >= %s
+        """,
+        (MIN_RANK_ID, since),
+    )
+    for rl_id, map_id, rank_id, mode_id in cursor.fetchall():
+        rl_id_int = int(rl_id)
+        rank_logs[rl_id_int] = RankLogEntry(
+            id=rl_id_int,
+            map_id=int(map_id),
+            rank_id=int(rank_id),
+            mode_id=int(mode_id) if mode_id is not None else None,
+            date_key=str(rl_id)[:8],
+        )
+
+    logger.info("バトルログ情報を読み込んでいます")
+    cursor.execute(
+        """
+        SELECT bl.id, bl.rank_log_id
+        FROM battle_logs bl
+        JOIN rank_logs rl ON bl.rank_log_id = rl.id
+        WHERE rl.rank_id >= %s AND SUBSTRING(rl.id, 1, 8) >= %s
+        """,
+        (MIN_RANK_ID, since),
+    )
+    battle_rank_map: Dict[int, int] = {}
+    for battle_log_id, rank_log_id in cursor.fetchall():
+        battle_rank_map[int(battle_log_id)] = int(rank_log_id)
+
+    logger.info("勝敗ログを読み込んでいます")
+    cursor.execute(
+        """
+        SELECT wl.battle_log_id, wl.win_brawler_id, wl.lose_brawler_id
+        FROM win_lose_logs wl
+        JOIN battle_logs bl ON wl.battle_log_id = bl.id
+        JOIN rank_logs rl ON bl.rank_log_id = rl.id
+        WHERE rl.rank_id >= %s AND SUBSTRING(rl.id, 1, 8) >= %s
+        """,
+        (MIN_RANK_ID, since),
+    )
+
+    def _team_factory() -> Dict[str, Set[int]]:
+        return {"win": set(), "lose": set()}
+
+    battle_teams: Dict[int, Dict[str, Set[int]]] = defaultdict(_team_factory)
+    for battle_log_id, win_brawler_id, lose_brawler_id in cursor.fetchall():
+        battle_id = int(battle_log_id)
+        if battle_id not in battle_rank_map:
+            continue
+        battle_teams[battle_id]["win"].add(int(win_brawler_id))
+        battle_teams[battle_id]["lose"].add(int(lose_brawler_id))
+
+    logger.info("スター獲得ログを読み込んでいます")
+    cursor.execute(
+        """
+        SELECT rsl.rank_log_id, rsl.star_brawler_id
+        FROM rank_star_logs rsl
+        JOIN rank_logs rl ON rsl.rank_log_id = rl.id
+        WHERE rl.rank_id >= %s AND SUBSTRING(rl.id, 1, 8) >= %s
+        """,
+        (MIN_RANK_ID, since),
+    )
+    star_logs: List[Tuple[int, int]] = []
+    for rank_log_id, star_brawler_id in cursor.fetchall():
+        rl_id_int = int(rank_log_id)
+        if rl_id_int not in rank_logs:
+            continue
+        star_logs.append((rl_id_int, int(star_brawler_id)))
+
+    cursor.close()
+
+    battles: List[RankedBattle] = []
+    for battle_log_id, rank_log_id in battle_rank_map.items():
+        rank_entry = rank_logs.get(rank_log_id)
+        if rank_entry is None:
+            continue
+        teams = battle_teams.get(battle_log_id)
+        win_team: Tuple[int, ...] = ()
+        lose_team: Tuple[int, ...] = ()
+        if teams:
+            if teams["win"]:
+                win_team = tuple(sorted(int(b) for b in teams["win"]))
+            if teams["lose"]:
+                lose_team = tuple(sorted(int(b) for b in teams["lose"]))
+        battles.append(
+            RankedBattle(
+                battle_log_id=battle_log_id,
+                rank_log_id=rank_log_id,
+                map_id=rank_entry.map_id,
+                rank_id=rank_entry.rank_id,
+                mode_id=rank_entry.mode_id,
+                win_brawlers=win_team,
+                lose_brawlers=lose_team,
+            )
+        )
+
+    logger.info("ランクログ: %d件, バトル: %d件を読み込みました", len(rank_logs), len(battles))
+    return StatsDataset(rank_logs=rank_logs, battles=battles, star_logs=star_logs)
+


### PR DESCRIPTION
## Summary
- add a shared stats_loader module and update individual export scripts to consume the in-memory dataset
- introduce export_all_stats orchestrator that loads data once, fan-outs to each export, and update the pipeline script to use it
- preserve existing compute functions while reworking fetch_* helpers to aggregate from the common dataset

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68cecb5adcd8832b8fcd9c749efd0188