### PR TITLE
Remove unused brawler_used_ranks references

### DIFF
--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -30,17 +30,6 @@ CREATE TABLE IF NOT EXISTS _brawlers (
     name_ja VARCHAR(255) UNIQUE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
-CREATE TABLE IF NOT EXISTS brawler_used_ranks (
-    brawler_id INT NOT NULL,
-    map_id INT NOT NULL,
-    rank_id INT NOT NULL,
-    count INT NOT NULL DEFAULT 0,
-    PRIMARY KEY (brawler_id, map_id, rank_id),
-    FOREIGN KEY (brawler_id) REFERENCES _brawlers(id),
-    FOREIGN KEY (map_id) REFERENCES _maps(id),
-    FOREIGN KEY (rank_id) REFERENCES _ranks(id)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
-
 CREATE TABLE IF NOT EXISTS rank_logs (
     id VARCHAR(50) PRIMARY KEY,
     map_id INT NOT NULL,

--- a/src/fetch_battlelog.py
+++ b/src/fetch_battlelog.py
@@ -397,22 +397,6 @@ def fetch_battle_logs(player_tag: str, api_key: str) -> tuple[int, int, int]:
                         "ON DUPLICATE KEY UPDATE star_brawler_id=VALUES(star_brawler_id)",
                         (rank_log_id, star_brawler_id),
                     )
-                for rlog in resultInfo:
-                    for brawler_id in rlog.brawlers:
-                        cur.execute(
-                            "SELECT count FROM brawler_used_ranks WHERE brawler_id=%s AND map_id=%s AND rank_id=%s",
-                            (brawler_id, map_id, rank_id),
-                        )
-                        if cur.fetchone():
-                            cur.execute(
-                                "UPDATE brawler_used_ranks SET count = count + 1 WHERE brawler_id=%s AND map_id=%s AND rank_id=%s",
-                                (brawler_id, map_id, rank_id),
-                            )
-                        else:
-                            cur.execute(
-                                "INSERT INTO brawler_used_ranks(brawler_id, map_id, rank_id, count) VALUES (%s, %s, %s, 1)",
-                                (brawler_id, map_id, rank_id),
-                            )
                 new_rank_brawlers_flag = False
 
             #新規バトル登録


### PR DESCRIPTION
## Summary
- remove the unused brawler_used_ranks table from the schema
- stop updating brawler usage counters during battle log ingestion

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d74208ad5c832b8c0e726ba6753c35