### PR TITLE
プレイヤーメンテナンス用SQLスクリプトを追加

### DIFF
--- a/sql/count_players_without_name.sql
+++ b/sql/count_players_without_name.sql
@@ -1,0 +1,7 @@
+-- 名前がNULLのプレイヤー数を出力するクエリ
+SELECT
+    COUNT(*) AS unnamed_player_count
+FROM
+    players
+WHERE
+    name IS NULL;

--- a/sql/delete_players_below_rank_10.sql
+++ b/sql/delete_players_below_rank_10.sql
@@ -1,0 +1,5 @@
+-- 最高ランクが9以下のプレイヤーを削除し、削除した件数を出力するスクリプト
+DELETE FROM players
+WHERE highest_rank <= 9;
+
+SELECT ROW_COUNT() AS deleted_low_rank_player_count;

--- a/sql/delete_players_without_name.sql
+++ b/sql/delete_players_without_name.sql
@@ -1,0 +1,5 @@
+-- 名前がNULLのプレイヤーを削除し、削除した件数を出力するスクリプト
+DELETE FROM players
+WHERE name IS NULL;
+
+SELECT ROW_COUNT() AS deleted_unnamed_player_count;

--- a/sql/delete_rank_logs_rank_3_and_below.sql
+++ b/sql/delete_rank_logs_rank_3_and_below.sql
@@ -1,0 +1,24 @@
+-- ランク3以下のランクマッチログと関連ログを削除するスクリプト
+-- 1. 勝敗ログを削除
+DELETE FROM win_lose_logs
+WHERE battle_log_id IN (
+    SELECT bl.id
+    FROM battle_logs AS bl
+    INNER JOIN rank_logs AS rl ON bl.rank_log_id = rl.id
+    WHERE rl.rank_id <= 3
+);
+
+-- 2. バトルログを削除
+DELETE FROM battle_logs
+WHERE rank_log_id IN (
+    SELECT rl.id
+    FROM rank_logs AS rl
+    WHERE rl.rank_id <= 3
+);
+
+-- 3. ランクマッチログを削除（rank_star_logsはON DELETE CASCADE）
+DELETE FROM rank_logs
+WHERE rank_id <= 3;
+
+-- 4. 削除件数を出力
+SELECT ROW_COUNT() AS deleted_rank_log_count;

--- a/sql/rank_match_count_by_rank.sql
+++ b/sql/rank_match_count_by_rank.sql
@@ -1,0 +1,15 @@
+-- ランク別のランクマッチ数を出力するクエリ
+SELECT
+    r.id AS rank_id,
+    r.name AS rank_name,
+    r.name_ja AS rank_name_ja,
+    COUNT(rl.id) AS rank_match_count
+FROM
+    rank_logs AS rl
+    INNER JOIN _ranks AS r ON rl.rank_id = r.id
+GROUP BY
+    r.id,
+    r.name,
+    r.name_ja
+ORDER BY
+    r.id;


### PR DESCRIPTION
## Summary
- ランク別のランクマッチ数を取得するクエリを追加
- 名前がNULLのプレイヤーを集計および削除するスクリプトを追加
- 低ランクプレイヤーとランク3以下のランクマッチログを整理するスクリプトを追加

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e219d482a4832bb89411c1825cdcf1