### PR TITLE
Add SQL query for rank match count from target date

### DIFF
--- a/sql/rank_match_count_since_target_date.sql
+++ b/sql/rank_match_count_since_target_date.sql
@@ -1,0 +1,8 @@
+-- 対象期間（対象日付から現在）でのランクマッチ件数を出力するクエリ
+-- 対象日付は YYYYMMDD 形式で ? プレースホルダに指定してください。
+SELECT
+    COUNT(*) AS rank_match_count
+FROM
+    rank_logs AS rl
+WHERE
+    SUBSTRING(rl.id, 1, 8) BETWEEN ? AND DATE_FORMAT(CURRENT_DATE, '%Y%m%d');


### PR DESCRIPTION
## Summary
- add a SQL query that counts rank matches from a provided start date through the current date
- document how to supply the start date parameter using a YYYYMMDD formatted value

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e23a60c6c8832b84ca5c1db4318a90