### PR TITLE
Add SQL query for player counts by rank

### DIFF
--- a/sql/player_count_by_rank.sql
+++ b/sql/player_count_by_rank.sql
@@ -1,0 +1,15 @@
+-- ランク別のプレイヤー数を出力するクエリ
+SELECT
+    r.id AS rank_id,
+    r.name AS rank_name,
+    r.name_ja AS rank_name_ja,
+    COUNT(p.tag) AS player_count
+FROM
+    _ranks AS r
+    LEFT JOIN players AS p ON p.highest_rank = r.id
+GROUP BY
+    r.id,
+    r.name,
+    r.name_ja
+ORDER BY
+    r.id;


### PR DESCRIPTION
## Summary
- add a SQL script that reports the number of players for each rank by joining players with the rank master table

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e33504e104832b88d4c34954a5999f